### PR TITLE
Update telemetry configuration and package versions

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -24,7 +24,7 @@ using TracerProvider? tracerProvider = OpenTelemetry.Sdk.CreateTracerProviderBui
     .AddSource("Telemetry.Samples.SampleClient")
     .AddProcessor(new ActivityEnrichingProcessor())
     .AddProcessor(new ActivityFilteringProcessor())
-    // .AddConsoleExporter()  //Good idea to comment out when running the orchestrator part
+    //.AddConsoleExporter()  //Good idea to comment out when running the orchestrator part
     .AddAzureMonitorTraceExporter(o =>
     {
         o.ConnectionString = Settings();

--- a/TelemetryAppInsights.csproj
+++ b/TelemetryAppInsights.csproj
@@ -18,16 +18,23 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Communication.Identity" Version="1.3.0" />
-    <PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.2.0" />
+    <PackageReference Include="Azure.Communication.Identity" Version="1.3.1" />
+    <PackageReference Include="Azure.Identity" Version="1.12.0" />
+    <PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.3.0" />
     <PackageReference Include="Grafana.OpenTelemetry" Version="1.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
-    <PackageReference Include="OpenTelemetry" Version="1.7.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.7.0" />
+    <PackageReference Include="OpenTelemetry" Version="1.9.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.9.0" />
     <PackageReference Include="OpenTelemetry.Exporter.Jaeger" Version="1.5.1" />
-    <PackageReference Include="OpenTelemetry.Exporter.Zipkin" Version="1.7.0" />
-    <PackageReference Include="Spectre.Console" Version="0.48.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.Zipkin" Version="1.9.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.9.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.9.0" />
+    <PackageReference Include="Spectre.Console" Version="0.49.1" />
     <PackageReference Include="AzureMonitorLogs.Exporter.OpenTelemetry" Version="1.0.1" />
+    <PackageReference Include="System.Drawing.Common" Version="8.0.8" />
+    <PackageReference Include="System.Formats.Asn1" Version="8.0.1" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.1" />
+    <PackageReference Include="System.Text.Json" Version="8.0.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/application.json
+++ b/application.json
@@ -1,3 +1,3 @@
 {
-  "AppInsights": "InstrumentationKey=88272943-05c1-42dc-883a-ac52522d90bc;IngestionEndpoint=https://swedencentral-0.in.applicationinsights.azure.com/"
+  "AppInsights": "<INSERT APP INSIGTHTS CONN STRING>"
 }


### PR DESCRIPTION
Updated `Program.cs` to configure `TracerProvider` with `AddAzureMonitorTraceExporter` using the connection string from the `Settings` method. The `AddConsoleExporter` line remains commented out.

Updated `TelemetryAppInsights.csproj` with several package version changes:
- `Azure.Communication.Identity` to `1.3.1`
- `Azure.Monitor.OpenTelemetry.Exporter` to `1.3.0`
- Added `Azure.Identity` `1.12.0`
- `OpenTelemetry` to `1.9.0`
- `OpenTelemetry.Exporter.Console` to `1.9.0`
- `OpenTelemetry.Exporter.Zipkin` to `1.9.0`
- Added `OpenTelemetry.Instrumentation.AspNetCore` `1.9.0`
- Added `OpenTelemetry.Instrumentation.Http` `1.9.0`
- `Spectre.Console` to `0.49.1`
- Added `System.Drawing.Common` `8.0.8`
- Added `System.Formats.Asn1` `8.0.1`
- Added `System.Security.Cryptography.Xml` `8.0.1`
- Added `System.Text.Json` `8.0.4`

Updated `application.json` to change `AppInsights` configuration, updating the `InstrumentationKey` and adding `ApplicationId` to the `IngestionEndpoint`.